### PR TITLE
fix kubernetes cluster-id generation

### DIFF
--- a/bluelabs-publish-operator.sh
+++ b/bluelabs-publish-operator.sh
@@ -1,4 +1,4 @@
-current_version="1.0.7"
+current_version="1.0.8"
 debug=false
 while true; do
     read -p "Build as debug version? [no]: " yn

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lyft-flink-k8s-operator
-version: 1.0.15
-appVersion: 1.0.7
+version: 1.0.16
+appVersion: 1.0.8
 description: Flink Operator by Lyft
 type: application
 keywords:

--- a/pkg/controller/flink/container_utils.go
+++ b/pkg/controller/flink/container_utils.go
@@ -2,12 +2,10 @@ package flink
 
 import (
 	"fmt"
+	"github.com/benlaurie/objecthash/go/objecthash"
 	"hash/fnv"
 	"math/rand"
 	"strings"
-	"time"
-
-	"github.com/benlaurie/objecthash/go/objecthash"
 
 	"github.com/lyft/flinkk8soperator/pkg/apis/app/v1beta1"
 	"github.com/lyft/flinkk8soperator/pkg/controller/common"
@@ -212,9 +210,9 @@ func InjectOperatorCustomizedConfig(deployment *appsv1.Deployment, app *v1beta1.
 		for _, env := range container.Env {
 			if env.Name == OperatorFlinkConfig {
 				if isHAEnabled(app.Spec.FlinkConfig) {
-					env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s-%s\n", env.Value, app.Name, hash, time.Now().Format("20060102150405"))
+					env.Value = fmt.Sprintf("%s\nhigh-availability.cluster-id: %s-%s\n", env.Value, app.Name, hash)
 					if !strings.Contains(env.Value, "kubernetes.cluster-id") {
-						env.Value = fmt.Sprintf("%s\nkubernetes.cluster-id: %s-%s-%s\n", env.Value, app.Name, hash, time.Now().Format("20060102150405"))
+						env.Value = fmt.Sprintf("%s\nkubernetes.cluster-id: %s-%s\n", env.Value, app.Name, hash)
 					}
 					if deploymentType == FlinkDeploymentTypeJobmanager {
 						env.Value = fmt.Sprintf("%sjobmanager.rpc.address: $HOST_IP\n", env.Value)


### PR DESCRIPTION
Fixing injection of cluster id property.
We should not use now timestamp as this can result in different value assigned to jobManager and taskManagers if is not executed in same second. Deployment hash should be enough. If values is not the same, task managers wont be able to connect to job manager